### PR TITLE
深さ3以上のフォルダがコピーできないバグの修正

### DIFF
--- a/skybu/common.h
+++ b/skybu/common.h
@@ -82,8 +82,9 @@ struct MyFile {
 	void setFlags(DWORD dwFlags);
 	void setData(const MyFile &parent, const wstring &filename);
 	void setData(const MyFile &parent, const wstring &filename, DWORD dwFlags);
-	void backupFileIfChanged(sqlite3* sql3, int64_t parent, const wstring& hashPath, const string &dateTag);
+	void recordFileIfChanged(sqlite3* sql3, int64_t parent, const wstring& hashPath, const string& dateTag);
 	void recordDirIfChanged(sqlite3* sql3, const MyFile &root, int64_t parent, const string &dateTag);
+	void recordFileDir(sqlite3* sql3, const string& dateTag, int64_t folder_id, int64_t file_id, const wstring& hashFile);
 	void backup(const wstring& hashPath);
 	int64_t createNewFolderDB(sqlite3* sql3, int64_t parent);
 	int64_t createNewFileDB(sqlite3* sql3, int64_t folder_id, const wstring& hashPath);

--- a/skybu/common.h
+++ b/skybu/common.h
@@ -7,12 +7,12 @@ struct MyDrive {
 	wstring guid;
 	wstring name;
 	MyDrive() : id(-1LL), guid(), name(L"D") {}
-	void UpdateDrives(sqlite3* sql, const wstring& arg, const wstring &drv);
+	void UpdateDrives(sqlite3* sql, const wstring &drv);
 };
 
 struct MyFile;
 
-BOOL FindRoot(vector<wstring>& v, const wstring &arg);
+BOOL FindRoot(wstring& v, const wstring &arg);
 wstring  whoAmI();
 wstring driveToGuid(TCHAR driveLetter);
 string utf16_to_utf8(const std::wstring& s);
@@ -20,8 +20,7 @@ string utf16_to_utf8(const std::wstring& s);
 wstring hashFileName(const MyFile& file, bool flg_root);
 //wstring hashFile(const wstring &fileName);
 wstring GetDriveNameFromPath(const wstring &pathName);
-wstring GetDirNameFromPath(const wstring &pathName, int64_t parent);
-wstring GetPathWithoutHostname(const wstring& pathName);
+wstring GetDirNameFromPath(const wstring& pathName);
 LPCTSTR GetFileNameFromPath(const wstring &pathName);
 BOOL CreateSql3Database(LPCTSTR lpctDB);
 #define DATABASE_SCHEMA L"skybu.sql"
@@ -35,10 +34,12 @@ tuple<int, string, string> getBackupHistory(sqlite3* sql3);
 extern BCRYPT_ALG_HANDLE hAlg;
 extern wstring hostname;
 extern wstring szRoot;
-extern wstring szSource;
+extern wstring srcDir;
 extern string dateTag;
 extern boolean isLastFinished;
 extern string last_startTime;
+extern wstring srcDrive;
+extern wstring dstDrive;
 
 struct MySid {
 	SID sid;
@@ -67,17 +68,21 @@ struct MyFileAttribute {
 
 struct MyFile {
 	MyDrive drive;
-	wstring path;
+	wstring dname;
 	wstring fname;
 	MyFileAttribute attr;
-	MyFile(const MyDrive& drive) : drive(drive) {}
+	MyFile(const MyDrive& drive, const wstring &dname) : drive(drive), dname(dname) {}
 	MyFile() {}
 	bool operator < (const MyFile& mf) const {
-		return fname == mf.fname ? attr.mtime < mf.attr.mtime : fname < mf.fname;
+		wstring c = dname + TEXT("\\") + fname;
+		wstring cs = mf.dname + TEXT("\\") + mf.fname;
+		return c == cs ? attr.mtime < mf.attr.mtime : c < cs;
 	}
 	const wstring getPath() const {
-		return TEXT("\\\\?\\") + szSource + TEXT("\\") + drive.name + path;
+		wstring f = !fname.empty() ? (TEXT("\\") + fname) : TEXT("");
+		return TEXT("\\\\?\\") + srcDrive + TEXT(":") + dname + f;
 	}
+	BOOL DoBackup(sqlite3* sql3, int64_t parent, int64_t folder_id, int64_t file_id, const string &date_tag);
 	void setFname(const MyFile &parent, const wstring &filename);
 	void setFlags(DWORD dwFlags);
 	void setData(const MyFile &parent, const wstring &filename);

--- a/skybu/skybu.sql
+++ b/skybu/skybu.sql
@@ -9,6 +9,7 @@ DROP INDEX IF EXISTS files_owner_idx;
 DROP INDEX IF EXISTS foldername_idx;
 DROP INDEX IF EXISTS folders_hash_idx;
 DROP INDEX IF EXISTS date_tag_idx;
+DROP INDEX IF EXISTS files_to_copy_idx;
 DROP TABLE IF EXISTS copy_logs;
 DROP TABLE IF EXISTS file_group;
 DROP TABLE IF EXISTS files;
@@ -116,3 +117,4 @@ CREATE TABLE files_to_copy (
 	hash_name varchar(64) not null,
 	created_at datetime not null default current_timestamp
 );
+CREATE UNIQUE INDEX files_to_copy_idx on files_to_copy(date_tag, file_id);

--- a/skybu/skybu.sql
+++ b/skybu/skybu.sql
@@ -18,12 +18,14 @@ DROP TABLE IF EXISTS prohibits;
 DROP TABLE IF EXISTS groups;
 DROP TABLE IF EXISTS owners;
 DROP TABLE IF EXISTS backup_history;
+DROP TABLE IF EXISTS files_to_copy;
 
+--- history of backup execution
 CREATE TABLE backup_history (
 	id integer primary key autoincrement,
 	date_tag date not null,
 	start_at datetime not null default current_timestamp,
-	end_at datetime
+	end_at datetime default null
 );
 
 --- File owner
@@ -101,3 +103,16 @@ CREATE TABLE file_group (
 	file_group_id integer not null
 );
 
+--- list of files to copy
+CREATE TABLE files_to_copy (
+	id integer primary key autoincrement,
+	date_tag date not null,
+	folder_id integer not null,
+	file_id integer not null,
+	flg_symbolic integer(1) default 0,
+	flg_directory integer(1) default 0,
+	flg_archive integer(1) default 0,
+	flg_hidden integer(1) default 0,
+	hash_name varchar(64) not null,
+	created_at datetime not null default current_timestamp
+);

--- a/skybu/utils.cpp
+++ b/skybu/utils.cpp
@@ -452,8 +452,23 @@ void MyFile::recordDirIfChanged(sqlite3* sql3, const MyFile &root, int64_t paren
 	wcout << L"root_path=" << root.path << L", file_id=" << file_id << L", copy_log_id=" << cl_id << endl;
 }
 
+// 未完了ファイル一覧テーブルにレコードを登録する
+void MyFile::recordFileDir(sqlite3* sql3, const string& dateTag, int64_t folder_id, int64_t file_id, const wstring& hashFile) {
+	sqlite3_stmt* stmt;
+	sqlite3_prepare16_v3(sql3,
+		L"INSERT INTO files_to_copy (date_tag, folder_id, file_id, flg_symbolic, flg_archive, flg_hidden, hash_name) VALUES(?, ?, ?, ?, ?, ?, ?)", -1, 0, &stmt, NULL);
+	sqlite3_bind_text(stmt, 1, dateTag.data(), dateTag.length(), NULL);
+	sqlite3_bind_int64(stmt, 2, folder_id);
+	sqlite3_bind_int64(stmt, 3, file_id);
+	sqlite3_bind_int(stmt, 4, attr.flg_symbolic);
+	sqlite3_bind_int(stmt, 5, attr.flg_archive);
+	sqlite3_bind_int(stmt, 6, attr.flg_hidden);
+	sqlite3_bind_text16(stmt, 7, hashFile.data(), hashFile.length() * sizeof(TCHAR), NULL);
+	sqlite3_step(stmt);
+}
+
 // 新規 or 更新ならバックアップ
-void MyFile::backupFileIfChanged(sqlite3* sql3, int64_t parent, const wstring& hashPath, const string &dateTag) {
+void MyFile::recordFileIfChanged(sqlite3* sql3, int64_t parent, const wstring& hashPath, const string &dateTag) {
 	sqlite3_stmt* stmt;
 	if (sqlite3_prepare16_v3(sql3,
 		L"SELECT l.*, f.folder_id FROM copy_logs l \
@@ -466,7 +481,7 @@ void MyFile::backupFileIfChanged(sqlite3* sql3, int64_t parent, const wstring& h
 	sqlite3_bind_text16(stmt, 1, hashPath.data(), hashPath.length() * sizeof(TCHAR), NULL);
 	int64_t folder_id = -1;
 	int64_t file_id = -1;
-	int64_t log_id = -1;
+	boolean isChanged = false;
 	if (sqlite3_step(stmt) == SQLITE_ROW) {
 		string mtimeOld = (const char *)sqlite3_column_text(stmt, 3);
 		string created_at = (const char*)sqlite3_column_text(stmt, 10);
@@ -475,7 +490,7 @@ void MyFile::backupFileIfChanged(sqlite3* sql3, int64_t parent, const wstring& h
 			// 更新ファイル
 			folder_id = sqlite3_column_int64(stmt, 11);
 			file_id = sqlite3_column_int64(stmt, 1);
-			log_id = createNewLogDBFile(sql3, file_id, dateTag);
+			isChanged = true;
 		}
 	}
 	else {
@@ -483,22 +498,90 @@ void MyFile::backupFileIfChanged(sqlite3* sql3, int64_t parent, const wstring& h
 			// 新規ファイル
 			folder_id = createNewFolderDB(sql3, parent);
 			file_id = createNewFileDB(sql3, folder_id, hashPath);
-			log_id = createNewLogDBFile(sql3, file_id, dateTag);
+			isChanged = true;
 		}
 	}
 
 	sqlite3_finalize(stmt);
-	if (log_id != -1) {
+	if (isChanged) {
+		recordFileDir(sql3, dateTag, folder_id, file_id, hashFileName(*this, false));
+	}
+}
+
+// バックアップを実行する
+BOOL DoBackup(sqlite3* sql3, const MyFile& root, int64_t parent, const string& dateTag) {
+
+	sqlite3_stmt* stmt;
+	if (sqlite3_prepare16_v3(sql3, L"SELECT file.id, file.date_tag, \
+		CASE WHEN folders.folder_path = '?root?' THEN '' ELSE folders.folder_path END, \
+		file.filename, file.file_id, file.hash_name, \
+		file.flg_archive, file.flg_directory, file.flg_hidden, file.flg_symbolic \
+		FROM folders \
+		INNER JOIN( \
+			SELECT tc.*, files.filename \
+			FROM files \
+			INNER JOIN files_to_copy tc \
+			ON tc.hash_name IS NOT NULL AND files.hash_name = tc.hash_name) file \
+		ON file.folder_id = folders.id ORDER BY file.created_at;", -1, 0, &stmt, NULL) != SQLITE_OK) {
+		return FALSE;
+	}
+
+	// バックアップを実行する
+	while (sqlite3_step(stmt) == SQLITE_ROW) {
+		MyFile file(root.drive);
+		int64_t id = sqlite3_column_int64(stmt, 0);
+		file.path = (const TCHAR*)sqlite3_column_text16(stmt, 2);
+		file.path += TEXT("\\");
+		file.path += (const TCHAR*)sqlite3_column_text16(stmt, 3);
+		int64_t file_id = sqlite3_column_int64(stmt, 4);
+		const wstring hash_name = (const TCHAR*)sqlite3_column_text16(stmt, 5);
+		DWORD dwFlags = 0;
+		if (sqlite3_column_int64(stmt, 6) == 1) {
+			dwFlags |= FILE_ATTRIBUTE_ARCHIVE;
+		}
+		if (sqlite3_column_int64(stmt, 7) == 1) {
+			dwFlags |= FILE_ATTRIBUTE_DIRECTORY;
+			file.attr.flg_directory = true;
+		}
+		if (sqlite3_column_int64(stmt, 8) == 1) {
+			dwFlags |= FILE_ATTRIBUTE_HIDDEN;
+			file.attr.flg_hidden = true;
+		}
+		if (sqlite3_column_int64(stmt, 9) == 1) {
+			dwFlags |= FILE_ATTRIBUTE_REPARSE_POINT;
+		}
+		file.setFlags(dwFlags);
+
+		int64_t log_id = file.createNewLogDBFile(sql3, file_id, dateTag);
+
+		sqlite3_stmt* sub_stmt;
 		sqlite3_prepare16_v3(sql3,
 			L"UPDATE files SET latest_copy_log_id=? WHERE id=?",
-			-1, 0, &stmt, NULL
+			-1, 0, &sub_stmt, NULL
 		);
-		sqlite3_bind_int64(stmt, 1, log_id);
-		sqlite3_bind_int64(stmt, 2, file_id);
-		while (sqlite3_step(stmt) != SQLITE_DONE) {}
-		sqlite3_finalize(stmt);
-		backup(hashFileName(*this, false));
+		sqlite3_bind_int64(sub_stmt, 1, log_id);
+		sqlite3_bind_int64(sub_stmt, 2, file_id);
+		while (sqlite3_step(sub_stmt) != SQLITE_DONE) {}
+		sqlite3_finalize(sub_stmt);
+
+		wcout << TEXT("copying: ") << file.path << endl;
+		file.backup(hash_name);
+
+		// バックアップ予定一覧から削除
+		if (sqlite3_prepare16_v3(sql3, L"DELETE FROM files_to_copy where id=?", -1, 0, &sub_stmt, NULL) != SQLITE_OK) {
+			return FALSE;
+		}
+		sqlite3_bind_int64(sub_stmt, 1, id);
+		sqlite3_step(sub_stmt);
+		int rowCount = sqlite3_changes(sql3);
+		// cout << rowCount << " rows deleted by DELETE for " << id << endl;
+
+		if (timedOut) {
+			return FALSE;
+		}
 	}
+
+	return TRUE;
 }
 
 int64_t MyFile::createNewFolderDB(sqlite3* sql3, int64_t parent) {
@@ -658,7 +741,7 @@ tuple<int, string, string> getBackupHistory(sqlite3* sql3)
 	// 1件目は直近の完了回、または完了したことがない状態での初回
 	if (sqlite3_step(stmt) == SQLITE_ROW) {
 		start_time= (const char*)sqlite3_column_text(stmt, 0);
-		end_time = (sqlite3_column_bytes(stmt, 1) > 0) ? (const char*)sqlite3_column_text(stmt, 1) : "";
+		end_time = (sqlite3_column_type(stmt, 1) != SQLITE_NULL) ? (const char*)sqlite3_column_text(stmt, 1) : "";
 		date_tag = (const char*)sqlite3_column_text(stmt, 2);
 		ret_value = (end_time != "") ? 0 : 1;
 


### PR DESCRIPTION
深さ3以上のフォルダがコピーできない問題を解消しました。
テーブル files_to_copy は使用せず、また直接 DoBackup() を呼んで copy_logs を設定するよう修正しました。
その他もろもろ細かい所を修正。
